### PR TITLE
Fix compatibility with Bcube (temporary downgrade to 0.3.0) 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 [compat]
 AcceleratedKernels = "0.4.3"
 KernelAbstractions = "0.9"
-Bcube = "0.3"
+Bcube = "=0.3.0"
 
 [extras]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bcube version 0.3.1 introduced breaking changes that prevent this package from building/running correctly on GPU (Cuda).
Solution : Added a temporary compatibility constraint that pins Bcube to version 0.3.0, restoring functionality while we await a proper update. 